### PR TITLE
Add implementation to exposed openapi

### DIFF
--- a/docs/getting_started/openapi.md
+++ b/docs/getting_started/openapi.md
@@ -10,6 +10,24 @@ The source code is required to output OpenAPI as we extract descriptions from re
 
 You can then serve this document from your service when it's deployed if desirable.
 
+```crystal
+
+class OpenAPI < AC::Base
+  base "/openapi"
+
+  get "/docs" do
+    render yaml:  ActionController::OpenAPI.generate_open_api_docs(
+      title: "Application",
+      version: "0.0.1",
+      description: "App description for OpenAPI docs"
+    ).to_yaml
+  end  
+end
+
+```
+
+then visit your documentation at "http://localhost:3000/openapi/docs"
+
 ## Optimal results
 
 For optimal output it's recommended that you:

--- a/docs/getting_started/openapi.md
+++ b/docs/getting_started/openapi.md
@@ -15,12 +15,14 @@ You can then serve this document from your service when it's deployed if desirab
 class OpenAPI < AC::Base
   base "/openapi"
 
+  DOCS = ActionController::OpenAPI.generate_open_api_docs(
+    title: "Application",
+    version: "0.0.1",
+    description: "App description for OpenAPI docs"
+  ).to_yaml
+
   get "/docs" do
-    render yaml:  ActionController::OpenAPI.generate_open_api_docs(
-      title: "Application",
-      version: "0.0.1",
-      description: "App description for OpenAPI docs"
-    ).to_yaml
+    render yaml: DOCS
   end  
 end
 


### PR DESCRIPTION
I started my application by adding "action-controller" in dependencies.
The current documentation, about the generation of the openapi documentation, start from a clone of "spider-gazelle".

I propose this PR to expose the documentation generated on an endpoint whatever the starting point