### PR TITLE
bump action-controller version in getting started

### DIFF
--- a/docs/getting_started/README.md
+++ b/docs/getting_started/README.md
@@ -10,7 +10,7 @@ Add the dependency to your `shard.yml`:
 dependencies:
   action-controller:
     github: spider-gazelle/action-controller
-    version: ~> 5.1
+    version: ~> 5.6
 ```
 
 Run `shards install`.


### PR DESCRIPTION
a minor documentation update to follow `action-controller` versions